### PR TITLE
feat: render `mermaid` diagrams which stored on markdown articles directly as ```mermaid``` code blocks

### DIFF
--- a/src/Components/SEO.js
+++ b/src/Components/SEO.js
@@ -1,22 +1,11 @@
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
-import PAGES from '@/Structure/Pages';
-import { RiCreativeCommonsZeroFill } from 'react-icons/ri';
-
 
 /* Guard against duplicate inserts across multiple pages */
 const CDN_URL =
   "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js";
 const SCRIPT_ID = "mermaid-cdn";
 
-const MermaidScript = () => (
-  <script
-    id={SCRIPT_ID}
-    src={CDN_URL}
-    async
-    crossOrigin="anonymous"
-  />
-);
 
 const SEO = ({ title, description, name = 'Iurii Shapkarin', type = 'website', aeoScript }) => {
 


### PR DESCRIPTION
_White Mermaid turns diagrams into simple text, plays nicely with developer workflows, and is already supported almost everywhere, making it a natural choice for a documentation standard._ 

### This PR allow to render diagrams and even make it efficient (not in bundle, cdn dynamically loadded only when needed and removed from removed when it's unmounted) 

**CDN approach bcs lib is too heavy, but maybe I will replace that with dynamic import (it's in branch https://shapkarin/shapkarin.me/tree/feat/MermaidRender)**