### PR TITLE
refactor(ci): decompose GitHub Actions into three files with reusable job

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,12 @@
+name: asdasd
+
+on:
+  schedule:
+    - cron: '0 0 */5 * *'
+
+jobs:
+  call-deploy:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      environment-name: github-pages
+      deployment-description: "Autodeploy by cron schedule. $(date +'%Y-%m-%d')"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,12 @@
+name: Deploy on Push to Main
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  call-deploy:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      environment-name: github-pages
+      deployment-description: "Deploy on main changes. ${{ github.ref_name }}"

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -1,10 +1,14 @@
 name: Build and publish
 on:
-  schedule:
-    - cron: '0 0 */5 * *'
-  push:
-    branches: [ "main" ]
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      environment-name:
+        required: true
+        type: string
+      deployment-description:
+        required: false
+        type: string
+        default: "Deploy from ${{ github.ref_name }}"
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Disclaimer: This project is only a homepage, not an example of application archi
 This website has been under gradual development since 2013, with limited time dedicated to its progress.
 Proof => https://web.archive.org/web/20130801000000*/shapkarin.me
 
-The API for this site is [generated](https://github.com/shapkarin/shapkarin.me/tree/main/src/Generate-Backend) and stored as [JSON and Markdown](https://github.com/shapkarin/shapkarin.me/tree/gh-pages/api) on [GitHub Pages](https://github.com/shapkarin/shapkarin.me/blob/main/.github/workflows/build-deploy.yml)
+The API for this site is [generated](https://github.com/shapkarin/shapkarin.me/tree/main/src/Generate-Backend) and stored as [JSON and Markdown](https://github.com/shapkarin/shapkarin.me/tree/gh-pages/api) on [GitHub Pages](https://github.com/shapkarin/shapkarin.me/blob/main/.github/workflows/)
 It uses Github Actions to help with CI, and generates a static version.
 
 Generative art is from from 9 y.o. repository => [https://github.com/shapkarin/sketches](https://github.com/shapkarin/sketches)

--- a/src/Components/Footer/Footer.js
+++ b/src/Components/Footer/Footer.js
@@ -5,7 +5,7 @@ import './style.less';
 const Footer = () =>
     <footer className="Footer">
         The API for this site <Link href="https://github.com/shapkarin/shapkarin.me/tree/master/src/Generate-Backend">is generated</Link> and stored as <Link href="https://github.com/shapkarin/shapkarin.me/tree/gh-pages/api">JSON and Markdown</Link> on GitHub Pages.<br />
-        It <Link href="https://github.com/shapkarin/shapkarin.me/blob/main/.github/workflows/build-deploy.yml">uses Github Actions</Link> to help with CI and generates a static version.
+        It <Link href="https://github.com/shapkarin/shapkarin.me/blob/main/.github/workflows">uses Github Actions</Link> to help with CI and generates a static version.
     </footer>
 
 export default Footer;


### PR DESCRIPTION
- docs: Github Actions link to the folder instead of file
- refactor(ci): decompose GitHub Actions into three files with reusable job