### PR TITLE
(testing google jules) feat: Generate sitemap.xml automatically during GitHub action build

### DIFF
--- a/.github/workflows/job.yml
+++ b/.github/workflows/job.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -42,6 +42,12 @@ jobs:
 
       - name: Copy HTML gallery
         run: npm run build:html-gallery 
+
+      - name: Generate sitemap
+        uses: cicirello/generate-sitemap@v1
+        with:
+          base-url-path: https://shapkarin.me/
+          path-to-root: dist
 
       # - name: Set deploy date
       #   id: deploy-date


### PR DESCRIPTION
This change integrates `cicirello/generate-sitemap` into the GitHub action workflow to automatically generate a sitemap over the generated static HTML files in the `dist` directory, setting the URL to `https://shapkarin.me/` and ensuring it has access to complete Git history for proper `<lastmod>` metadata.

---
*PR created automatically by Jules for task [351087347375304912](https://jules.google.com/task/351087347375304912) started by @shapkarin*