### PR TITLE
Perf/embedded stylesheet

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,7 +1,67 @@
 const path = require("path");
 const CracoLessPlugin = require("craco-less");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 const webpack = require("webpack");
 const FontPreloadPlugin = require("webpack-font-preload-plugin");
+
+const createInlineCssHtmlPlugin = (htmlWebpackPlugin, tests) => {
+  const getInlinedTag = (publicPath, compilation, tag) => {
+    if (
+      tag.tagName !== 'link' ||
+      !tag.attributes ||
+      tag.attributes.rel !== 'stylesheet' ||
+      !tag.attributes.href
+    ) {
+      return tag;
+    }
+
+    const cssName = publicPath
+      ? tag.attributes.href.replace(publicPath, '')
+      : tag.attributes.href.replace(/^\//, '');
+
+    if (!tests.some((test) => cssName.match(test))) {
+      return tag;
+    }
+
+    const asset = compilation.getAsset(cssName);
+
+    if (asset == null) {
+      return tag;
+    }
+
+    const css = String(asset.source.source())
+      .replace(/\/\*# sourceMappingURL=.*?\*\/\s*$/s, '')
+      .replace(/<\/style/gi, '<\\/style');
+
+    return { tagName: 'style', innerHTML: css, closeTag: true };
+  };
+
+  return {
+    apply(compiler) {
+      if (compiler.options.mode !== 'production') {
+        return;
+      }
+
+      let publicPath = compiler.options.output.publicPath || '';
+
+      if (publicPath && !publicPath.endsWith('/')) {
+        publicPath += '/';
+      }
+
+      compiler.hooks.compilation.tap('InlineCssHtmlPlugin', (compilation) => {
+        const tagFunction = (tag) =>
+          getInlinedTag(publicPath, compilation, tag);
+
+        const hooks = htmlWebpackPlugin.getHooks(compilation);
+
+        hooks.alterAssetTagGroups.tap('InlineCssHtmlPlugin', (assets) => {
+          assets.headTags = assets.headTags.map(tagFunction);
+          assets.bodyTags = assets.bodyTags.map(tagFunction);
+        });
+      });
+    },
+  };
+};
 
 module.exports = {
   webpack: {
@@ -25,6 +85,7 @@ module.exports = {
       new FontPreloadPlugin({
         extensions: ['woff2'],
       }),
+      createInlineCssHtmlPlugin(HtmlWebpackPlugin, [/^static\/css\/main\..+\.css$/]),
     ],
   },
   plugins: [{ plugin: CracoLessPlugin }],

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-helmet-async": "2.0.5",
     "sitemap-generator-cli": "7.5.0",
     "sqlite3": "5.1.7",
+    "web-vitals": "5.3.0",
     "webpack-font-preload-plugin": "1.5.0"
   },
   "reactSnap": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import App from './App';
-import { IS_PRODUCTION } from '@/constants';
-// import reportWebVitals from './reportWebVitals';
+import { IS_PRODUCTION, IS_DEVELOPMENT } from '@/constants';
 
 const rootElement = document.getElementById('root');
 const GH_PAGES_CANT_HYDRATE = true; // turn on `hydrateRoot` to test
@@ -11,7 +10,8 @@ IS_PRODUCTION && GH_PAGES_CANT_HYDRATE
   ? hydrateRoot(rootElement, <App />)
   : createRoot(rootElement).render(<App />);
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-// reportWebVitals();
+if (IS_DEVELOPMENT) {
+  import('./reportWebVitals').then(({ reportWebVitals }) => {
+    reportWebVitals(metric => console.info('[web-vitals]', metric));
+  });
+}

--- a/src/reportWebVitals.js
+++ b/src/reportWebVitals.js
@@ -1,13 +1,24 @@
-// const reportWebVitals = onPerfEntry => {
-//   if (onPerfEntry && onPerfEntry instanceof Function) {
-//     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-//       getCLS(onPerfEntry);
-//       getFID(onPerfEntry);
-//       getFCP(onPerfEntry);
-//       getLCP(onPerfEntry);
-//       getTTFB(onPerfEntry);
-//     });
-//   }
-// };
+/*
+  I DON'T use any analytics on my homepage, and I DON'T track your data.
+  I do use ONLY Google Search Console. It's basically Google Webmaster Tools,
+  not webpage analytics that send your data somewhere else.
+  
+  Search Console has its own Core Web Vitals report for indexed pages. 
+  
+  => The code below is local only! <=
 
-// export default reportWebVitals;
+  Note: it can take a bit of time to generate the local report, and ofc the `Preserve log` option is useful.
+*/
+export const reportWebVitals = onPerfEntry => {
+  if (typeof onPerfEntry !== 'function') {
+    return;
+  }
+
+  import('web-vitals')
+    .then(({ onCLS, onINP, onLCP }) => {
+      onCLS(onPerfEntry);
+      onINP(onPerfEntry);
+      onLCP(onPerfEntry);
+    })
+    .catch(() => {});
+};


### PR DESCRIPTION
1. add embedded stylesheet inside <style> tag

2. Add local only web vitals
```
  I DON'T use any analytics on my homepage, and I DON'T track your data.
  I do use ONLY Google Search Console. It's basically Google Webmaster Tools,
  not webpage analytics that send your data somewhere else.
  
  Search Console has its own Core Web Vitals report for indexed pages. 
  
  => The code at `reportWebVitals.js` is local only! <=
 ```
 
 #93 